### PR TITLE
fix: Improve LSP client retrieval for backward compatibility

### DIFF
--- a/lua/garbage-day/utils.lua
+++ b/lua/garbage-day/utils.lua
@@ -8,7 +8,7 @@ local uv = vim.uv or vim.loop
 ---Stop all LSP clients, including the ones in other tabs.
 function M.stop_lsp()
   local config = vim.g.garbage_day_config
-  for _, client in pairs(vim.lsp.get_active_clients()) do
+  for _, client in pairs(vim.lsp.get_clients() or vim.lsp.get_active_clients()) do
     local is_lsp_client_excluded =
         vim.tbl_contains(config.excluded_lsp_clients, client.name)
 


### PR DESCRIPTION
### Summary
This pull request improves the method of retrieving LSP clients to avoid using deprecated functions. Specifically, it uses `vim.lsp.get_clients()` if available and falls back to `vim.lsp.get_active_clients()` otherwise.

### Changes
- Updated to use `vim.lsp.get_clients()` if it is available.
- Kept `vim.lsp.get_active_clients()` as a fallback for backward compatibility.
- For more details, please refer to the [Neovim deprecation documentation](https://neovim.io/doc/user/deprecated.html#vim.lsp.buf_get_clients()).

### Motivation
This change aims to improve compatibility across different versions of Neovim and avoid using deprecated functions in the future. Specifically, since `vim.lsp.buf_get_clients()` is deprecated, this change ensures that the code is not affected by its deprecation.

Thank you for reviewing this pull request.