### PR TITLE
Implement different notification providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ You can tweak them in case some particular LSP client don't start/stop correctly
 |--|--|--|
 | `aggressive_mode_ignore` | [here](https://github.com/Zeioth/garbage-day.nvim/blob/main/lua/garbage-day/config.lua) | Buffers to ignore on `aggressive_mode`. |
 | `notifications` | `false` | Set it to `true` to get a notification every time LSP garbage collection triggers. |
+| `notification_engine` | `default` | Can be set to [figet](https://github.com/j-hui/fidget.nvim) or [notify](https://github.com/rcarriga/nvim-notify) to send notifications with those plugins. |
 | `retries` | `3` | Times to try to start a LSP client before giving up. |
 | `timeout` | `1000` | Milliseconds that will take for `retries` to complete. Example: by default we try 3 retries for 1000ms. |
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can tweak them in case some particular LSP client don't start/stop correctly
 |--|--|--|
 | `aggressive_mode_ignore` | [here](https://github.com/Zeioth/garbage-day.nvim/blob/main/lua/garbage-day/config.lua) | Buffers to ignore on `aggressive_mode`. |
 | `notifications` | `false` | Set it to `true` to get a notification every time LSP garbage collection triggers. |
-| `notification_engine` | `default` | Can be set to [figet](https://github.com/j-hui/fidget.nvim) or [notify](https://github.com/rcarriga/nvim-notify) to send notifications with those plugins. |
+| `notification_engine` | `default` | Can be set to [fidget](https://github.com/j-hui/fidget.nvim) or [notify](https://github.com/rcarriga/nvim-notify) to send notifications with those plugins. |
 | `retries` | `3` | Times to try to start a LSP client before giving up. |
 | `timeout` | `1000` | Milliseconds that will take for `retries` to complete. Example: by default we try 3 retries for 1000ms. |
 

--- a/lua/garbage-day/config.lua
+++ b/lua/garbage-day/config.lua
@@ -8,14 +8,15 @@ function M.set(opts)
     filetype = { "", "markdown", "text", "org", "tex", "asciidoc", "rst" },
     buftype = { "nofile" }
   }
-  M.excluded_lsp_clients = opts.excluded_lsp_clients or { 
-    "null-ls", "jdtls", "marksman" 
+  M.excluded_lsp_clients = opts.excluded_lsp_clients or {
+    "null-ls", "jdtls", "marksman"
   }
   M.grace_period = opts.grace_period or (60 * 15) -- seconds
   M.notifications = opts.notifications or false
   M.retries = opts.retries or 3                   -- times
   M.timeout = opts.timeout or 1000                -- ms
   M.wakeup_delay = opts.wakeup_delay or 0         -- ms
+  M.notification_engine = opts.notification_engine or "default"
 
   -- Expose globally
   vim.g.garbage_day_config = M

--- a/lua/garbage-day/init.lua
+++ b/lua/garbage-day/init.lua
@@ -50,7 +50,7 @@ function M.setup(opts)
         if grace_period_exceeded and not lsp_has_been_stopped then
           timer:stop()
           utils.stop_lsp()
-          if config.notifications then utils.notify("lsp_has_stopped") end
+          if config.notifications then utils.notify("lsp_has_stopped", config.notification_engine) end
           lsp_has_been_stopped = true
         end
       end))
@@ -69,7 +69,7 @@ function M.setup(opts)
           -- Start LSP
           if lsp_has_been_stopped then
             utils.start_lsp()
-            if config.notifications then utils.notify("lsp_has_started") end
+            if config.notifications then utils.notify("lsp_has_started", config.notification_engine) end
           end
 
           -- Reset state
@@ -101,7 +101,7 @@ function M.setup(opts)
           if config.aggressive_mode then
             utils.stop_lsp()
             utils.start_lsp()
-            if config.notifications then utils.notify "lsp_has_stopped" end
+            if config.notifications then utils.notify("lsp_has_stopped", config.notification_engine) end
           end
         end
         current_filetype = new_filetype

--- a/lua/garbage-day/utils.lua
+++ b/lua/garbage-day/utils.lua
@@ -65,17 +65,45 @@ end
 ---Sends a notification.
 ---@param kind string Accepted values are:
 ---{ "lsp_has_started", "lsp_has_stopped" }
-function M.notify(kind)
-  if kind == "lsp_has_started" then
-    vim.notify("Focus recovered. Starting LSP clients.",
-      vim.log.levels.INFO,
-      { title = "garbage-day.nvim" }
-    )
-  elseif kind == "lsp_has_stopped" then
-    vim.notify("Inactive LSP clients have been stopped to save resources.",
-      vim.log.levels.INFO,
-      { title = "garbage-day.nvim" }
-    )
+---@param engine string Accepted values are:
+---{ "default", "notify", "fidget" }
+function M.notify(kind, engine)
+  if engine == "notify" then
+      if kind == "lsp_has_started" then
+        require("notify")("Focus recovered. Starting LSP clients.",
+          vim.log.levels.INFO,
+          { title = "garbage-day.nvim" }
+        )
+      elseif kind == "lsp_has_stopped" then
+        require("notify")("Inactive LSP clients have been stopped to save resources.",
+          vim.log.levels.INFO,
+          { title = "garbage-day.nvim" }
+        )
+      end
+  elseif engine == "fidget" then
+      if kind == "lsp_has_started" then
+        require("fidget").notify("Focus recovered. Starting LSP clients.",
+          vim.log.levels.INFO,
+          { annotate = "garbage-day.nvim" }
+        )
+      elseif kind == "lsp_has_stopped" then
+        require("fidget").notify("Inactive LSP clients have been stopped to save resources.",
+          vim.log.levels.INFO,
+          { annotate = "garbage-day.nvim" }
+        )
+      end
+  else
+      if kind == "lsp_has_started" then
+        vim.notify("Focus recovered. Starting LSP clients.",
+          vim.log.levels.INFO,
+          { title = "garbage-day.nvim" }
+        )
+      elseif kind == "lsp_has_stopped" then
+        vim.notify("Inactive LSP clients have been stopped to save resources.",
+          vim.log.levels.INFO,
+          { title = "garbage-day.nvim" }
+        )
+      end
   end
 end
 


### PR DESCRIPTION
Added option to set `notification_engine` with `fidget` or `notify` which will send notifications with those plugins instead. If `notification_engine` is set to anything else then notifications are send with default `vim.notify`

Implements #10 