### PR TITLE
fix: stop lsp client indeed and handle rust-analyzer with rustaceanvim.

### DIFF
--- a/lua/garbage-day/utils.lua
+++ b/lua/garbage-day/utils.lua
@@ -1,6 +1,5 @@
 local M = {}
 
-
 -- CORE UTILS
 -- ----------------------------------------------------------------------------
 
@@ -9,13 +8,10 @@ function M.stop_lsp()
   local config = vim.g.garbage_day_config
   for _, client in pairs(vim.lsp.get_clients()) do
     local is_lsp_client_excluded =
-        vim.tbl_contains(config.excluded_lsp_clients, client.name)
+      vim.tbl_contains(config.excluded_lsp_clients, client.name)
 
     -- Stop lsp client
-    if not is_lsp_client_excluded then
-      vim.lsp.stop_client(client.id)
-      client.rpc.terminate()
-    end
+    if not is_lsp_client_excluded then client.stop() end
   end
 end
 
@@ -42,8 +38,8 @@ function M.start_lsp()
     vim.cmd(":LspStart")
 
     -- Start null-ls
-    local is_null_ls_excluded = vim.tbl_contains(
-      config.excluded_lsp_clients, "null-ls")
+    local is_null_ls_excluded =
+      vim.tbl_contains(config.excluded_lsp_clients, "null-ls")
     if not is_null_ls_excluded then
       pcall(function() require("null-ls").enable({}) end)
     end
@@ -66,12 +62,14 @@ end
 ---{ "lsp_has_started", "lsp_has_stopped" }
 function M.notify(kind)
   if kind == "lsp_has_started" then
-    vim.notify("Focus recovered. Starting LSP clients.",
+    vim.notify(
+      "Focus recovered. Starting LSP clients.",
       vim.log.levels.INFO,
       { title = "garbage-day.nvim" }
     )
   elseif kind == "lsp_has_stopped" then
-    vim.notify("Inactive LSP clients have been stopped to save resources.",
+    vim.notify(
+      "Inactive LSP clients have been stopped to save resources.",
       vim.log.levels.INFO,
       { title = "garbage-day.nvim" }
     )

--- a/lua/garbage-day/utils.lua
+++ b/lua/garbage-day/utils.lua
@@ -35,7 +35,12 @@ function M.start_lsp()
     end
 
     -- Start LSP
-    vim.cmd(":LspStart")
+    local ok, _ = pcall(require, "rustaceanvim")
+    if vim.bo.filetype == "rust" and ok then
+      vim.cmd(":RustAnalyzer start")
+    else
+      vim.cmd(":LspStart")
+    end
 
     -- Start null-ls
     local is_null_ls_excluded =


### PR DESCRIPTION
This patch adds two changes:
1. Use `client.stop()` to stop client and truly save memory. Current impl doesn't work for me, the lsp is still occupy lots of memory in the background.
2. Start the `rust-analyzer` managed by `rustaceanvim` correctly.